### PR TITLE
Prevent use of BTRFS

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -18,6 +18,19 @@ cp etc/modprobe.d/18Fhardened.conf /etc/modprobe.d/18Fhardened.conf
 chmod 0644 /etc/modprobe.d/18Fhardened.conf
 chown root:root /etc/modprobe.d/18Fhardened.conf
 
+### 
+# Disable modules for K8s kernels
+# Remove this once our K8s cluster is gone (early 2021)
+###
+
+if grep -xq "kubernetes" /var/vcap/instance/deployment ; then
+  cat >> /etc/modprobe.d/18Fhardened.conf <<ENDK8
+# K8s patches/mitigations
+install btrfs /bin/true
+install crypto_user /bin/true
+ENDK8
+fi
+
 ###
 # grub changes (workaround while we work with Nessus to fix scans)
 ###

--- a/jobs/harden/templates/files/etc/modprobe.d/18Fhardened.conf
+++ b/jobs/harden/templates/files/etc/modprobe.d/18Fhardened.conf
@@ -1,4 +1,4 @@
-#Applications
+# Filesystems
 
 install cramfs /bin/true
 install freevxfs /bin/true
@@ -7,6 +7,7 @@ install hfs /bin/true
 install hfsplus /bin/true
 install squashfs /bin/true
 install udf /bin/true
+install btrfs /bin/true
 
 # Protocols
 

--- a/jobs/harden/templates/files/etc/modprobe.d/18Fhardened.conf
+++ b/jobs/harden/templates/files/etc/modprobe.d/18Fhardened.conf
@@ -1,3 +1,8 @@
+# This file, 18Fhardened.conf, works to prevent module loading
+# even though most online advice is to use `blacklist` files or
+# files named for the module itself. Confirmed on Ubuntu 18.04
+# by Peter Burkholder, 2020-10-20, with strace and direct testing.
+
 # Filesystems
 
 install cramfs /bin/true
@@ -7,7 +12,6 @@ install hfs /bin/true
 install hfsplus /bin/true
 install squashfs /bin/true
 install udf /bin/true
-install btrfs /bin/true
 
 # Protocols
 
@@ -15,7 +19,3 @@ install dccp /bin/true
 install sctp /bin/true
 install rds /bin/true
 install tipc /bin/true
-
-# K8s patches
-# https://bugzilla.redhat.com/show_bug.cgi?id=1775021#c5 mitigation
-install crypto_user /bin/true

--- a/jobs/harden/templates/files/etc/modprobe.d/18Fhardened.conf
+++ b/jobs/harden/templates/files/etc/modprobe.d/18Fhardened.conf
@@ -15,3 +15,7 @@ install dccp /bin/true
 install sctp /bin/true
 install rds /bin/true
 install tipc /bin/true
+
+# K8s patches
+# https://bugzilla.redhat.com/show_bug.cgi?id=1775021#c5 mitigation
+install crypto_user /bin/true


### PR DESCRIPTION
This addresses https://nvd.nist.gov/vuln/detail/CVE-2019-18885

## Changes proposed in this pull request:

- Don't load any module for BTRFS for CVE-2019-18885
- Don't load any module for crypto_user per https://bugzilla.redhat.com/show_bug.cgi?id=1775021#c5 for  CVE-2019-19062

## security considerations

Improves security by disabling btrfs, crypto_user
