### PR TITLE
Disable loading of BFQ scheduler

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -30,6 +30,7 @@ install btrfs /bin/true
 install crypto_user /bin/true
 install nbd /bin/true
 install cipso_ipv4 /bin/true
+install bfq /bin/true
 ENDK8
 fi
 


### PR DESCRIPTION
From Red Hat Bugzilla – Bug 1832866:

“An issue was discovered in the Linux kernels implementation of BFQ IO scheduler.  A local user who is able to groom system memory may be able to cause kernel memory corruption and possibly privilege escalation through abusing a race condition in the IO scheduler.” 

This vulnerability is only exploitable if the BFQ I/O scheduler is in use.  Following, https://wiki.ubuntu.com/Kernel/Reference/IOSchedulers we see that bfq scheduling requires the `bfq` module so we have disabled loading that module

## Changes proposed in this pull request:
- disable BFQ
-
-

## security considerations

Alternate mitigation for potential issue.
