### PR TITLE
Disable loading of bcache

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -31,6 +31,7 @@ install crypto_user /bin/true
 install nbd /bin/true
 install cipso_ipv4 /bin/true
 install bfq /bin/true
+install bcache /bin/true
 ENDK8
 fi
 


### PR DESCRIPTION
It was discovered that the bcache subsystem in the Linux kernel did not
properly release a lock in some error conditions. A local attacker could
possibly use this to cause a denial of service. ([CVE-2020-12771](https://nvd.nist.gov/vuln/detail/CVE-2020-12771)) 

## Changes proposed in this pull request:
- Disable bcache

## security considerations
Alternate mitigation for potential issue.
