### PR TITLE
Ban nfs, sunrpc, vhost, etc.

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -35,10 +35,16 @@ install bcache /bin/true
 install zram /bin/true
 install rpcsec_gss_krb5 /bin/true
 install nfs /bin/true
-install vhost /bin/true # CVE-2020-10942
+install vhost /bin/true         # CVE-2020-10942
 install xfs /bin/true
-install overlay /bin/true # CVE-2020-16120
-install nfc /bin/true # CVE-2020-26088
+install overlay /bin/true       # CVE-2020-16120
+install nfc /bin/true           # CVE-2020-26088
+install intel_rapl /bin/true    # CVE-2020-8694 
+install ccp /bin/true           # (CVE-2019-18808) 
+install adis_lib /bin/true      # CVE-2019-19061
+install f2fs /bin/true          # CVE-2019-9445
+install kvm /bin/true           # CVE-2020-2732
+install ipmi_msghandler /bin/true # CVE-2019-19046
 ENDK8
 fi
 

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -33,7 +33,7 @@ install cipso_ipv4 /bin/true
 install bfq /bin/true
 install bcache /bin/true
 install zram /bin/true
-install sunrpc /bin/true
+install rpcsec_gss_krb5 /bin/true
 install nfs /bin/true
 install vhost /bin/true # CVE-2020-10942
 ENDK8

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -36,6 +36,8 @@ install zram /bin/true
 install rpcsec_gss_krb5 /bin/true
 install nfs /bin/true
 install vhost /bin/true # CVE-2020-10942
+install xfs /bin/true
+install overlay /bin/true # CVE-2020-16120
 ENDK8
 fi
 

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -38,6 +38,7 @@ install nfs /bin/true
 install vhost /bin/true # CVE-2020-10942
 install xfs /bin/true
 install overlay /bin/true # CVE-2020-16120
+install nfc /bin/true # CVE-2020-26088
 ENDK8
 fi
 

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -33,6 +33,9 @@ install cipso_ipv4 /bin/true
 install bfq /bin/true
 install bcache /bin/true
 install zram /bin/true
+install sunrpc /bin/true
+install nfs /bin/true
+install vhost /bin/true # CVE-2020-10942
 ENDK8
 fi
 

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -33,10 +33,10 @@ install cipso_ipv4 /bin/true
 install bfq /bin/true
 install bcache /bin/true
 install zram /bin/true
-install rpcsec_gss_krb5 /bin/true
-install nfs /bin/true
+install rpcsec_gss_krb5 /bin/true # CVE-2020-12656
+install nfs /bin/true           # multiple
 install vhost /bin/true         # CVE-2020-10942
-install xfs /bin/true
+install xfs /bin/true           # multiple
 install overlay /bin/true       # CVE-2020-16120
 install nfc /bin/true           # CVE-2020-26088
 install intel_rapl /bin/true    # CVE-2020-8694 


### PR DESCRIPTION
## Changes proposed in this pull request:

- (CVE-2020-10942) Medium 5.3 vhost
- (CVE-2020-24394) 7.1 High  NFS - `nfs` module is banned from loading.
- (CVE-2020-12656) 5.5 Medium - `rpcsec_gss_krb5` is banned 
- vhost CVE-2020-10942
- XFS (multiple)
- Overlay FS  CVE-2020-16120,  see alternative mitigation at: https://security.archlinux.org/CVE-2020-16120
- NFC https://nvd.nist.gov/vuln/detail/CVE-2020-26088
- A bunch more with references in-line.




## security considerations

This PR itself leaks some information, which is unfortunate, but as we're fully mitigating these issues/cves, I deem that OK.
