### PR TITLE
Updated to properly fix listed CVE

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -45,6 +45,7 @@ install adis_lib /bin/true      # CVE-2019-19061
 install f2fs /bin/true          # CVE-2019-9445
 install kvm /bin/true           # CVE-2020-2732
 install ipmi_msghandler /bin/true # CVE-2019-19046
+install usbtest /bin/true       # CVE-2020-15393
 ENDK8
 fi
 

--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -46,6 +46,7 @@ install f2fs /bin/true          # CVE-2019-9445
 install kvm /bin/true           # CVE-2020-2732
 install ipmi_msghandler /bin/true # CVE-2019-19046
 install usbtest /bin/true       # CVE-2020-15393
+install sunrpc /bin/true        # CVE-2020-12656
 ENDK8
 fi
 


### PR DESCRIPTION
This is still an issue even when there's no physical USB hardward, so we need to banlist the module from loading. 


I've tested this works to prevent loading on staging minion/0

## Changes proposed in this pull request:
-
-
-

## security considerations

Addresses potential security issues, no  side effects likely.
