### PR TITLE
remove systemd-timesyncd files

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -233,6 +233,13 @@ chown root: /etc/securetty
 chmod 0644 /etc/securetty
 
 ###
+# clean up after systemd-timesyncd
+###
+
+rm /var/lib/private/systemd/timesync/clock
+rmdir /var/lib/private/systemd/timesync
+
+###
 # install tcpwrappers
 ###
 apt-get upgrade -y tcpd


### PR DESCRIPTION
systemd-timesyncd runs with DynamicUser=true, so systemd allocates auser with a random uid/gid when it starts, and deallocates that when itterminates. In our case, this means systemd-timesyncd terminates and doesn't restart, leaving this file and directory abandoned with a random uid/gid, which nessus sees as a compliance/security issuesince we run chrony, we don't need systemd-timesyncd to be able to run, so deleting these files should be fine

## Changes proposed in this pull request:
- remove files orphaned by systemd-timesyncd

## security considerations
None