### PR TITLE
Removing removal of chrony

### DIFF
--- a/jobs/harden/templates/bin/post-deploy
+++ b/jobs/harden/templates/bin/post-deploy
@@ -217,7 +217,7 @@ sudo apt -y purge rsync
 # remove chrony
 ###
 
-sudo apt -y purge chrony
+# sudo apt -y purge chrony  # Needed for bosh-agent to configure ntp, chronyc is hardcoded into the agent
 
 ###
 # Limit logfile access


### PR DESCRIPTION
## Changes proposed in this pull request:
- Chrony is needed by the bosh agent to configure ntp, called in the `sync-time` script  https://github.com/cloudfoundry/bosh-agent/blob/main/platform/linux_platform.go#L615-L629
- Without this, time drifts on the vms, in the case of routers, time could drift forward and make TLS against certificates fail
- Ticket: tbd

## security considerations
This was pulled originally because of a nessus scan, but need to fix that test and not remove chrony
