### PR TITLE
use fips endpoint for blobstore

### DIFF
--- a/config/final.yml
+++ b/config/final.yml
@@ -3,5 +3,5 @@ blobstore:
   provider: s3
   options:
     bucket_name: 18f-boshrelease-blob
-
+    host: s3-fips.us-gov-west-1.amazonaws.com
 final_name: fisma-jammy


### PR DESCRIPTION
## Changes proposed in this pull request:

Set the host property to the fips endpoint

## security considerations

Instructs bosh to use the fips 140 compliant fips endpoint when interacting with S3.
